### PR TITLE
feat: Improved title description and removed margin

### DIFF
--- a/src/components/Landing/Tutorials/TutorialsPresenter.tsx
+++ b/src/components/Landing/Tutorials/TutorialsPresenter.tsx
@@ -47,19 +47,23 @@ const TutorialsPresenter = (props:Props) => {
                 Nacional de Transparencia.
               </p>
         
-              <div className='space-y-8'>
-            
-              {
-                props.tutorial.map((data) => {
+              <div>
+                {props.tutorial.map((data) => {
                   return (
                     <>
-                   
+                      <hr />
+                      <h2 className="text-center text-2xl font-semibold text-gray mb-2 mt-2">
+                        {data.title}
+                      </h2>
+                      <p className="text-gray-700 text-lg mb-6">
+                        {data.description}
+                      </p>
                       <Iframe title={data.title} link={formatUrlYoutube(data.url)} />
+                      <hr className="mt-2"/>
                     </>
-                  )
-                })
-              }
-            </div>
+                  );
+                })}
+              </div>
             </section>
             </main>
            


### PR DESCRIPTION
### 🐛 Problema
En el archivo TutorialsPresents.tsx, el componente `<Iframe>` recibe el título (title) y la URL del video (url), pero no está recibiendo la descripción (description). Esto causa que la descripción del tutorial no se muestre en el componente final.

### 💡 Solución
Se actualizó el mapeo de los elementos en props.tutorial para incluir la descripción. Además, se añadieron mejoras visuales, como un `<hr />` antes y después de cada tutorial, junto con encabezados estilizados para el título y párrafos para la descripción.

### 🧩 Código antes
```
{
  props.tutorial.map((data) => {
    return (
      <>
        <Iframe title={data.title} link={formatUrlYoutube(data.url)} />
      </>
    );
  });
}
```
### 🔧 Código después
```
{
  props.tutorial.map((data) => {
    return (
      <>
        <hr />
        <h2 className="text-center text-2xl font-semibold text-gray">
          {data.title}
        </h2>
        <Iframe title={data.title} link={formatUrlYoutube(data.url)} />
        <p className="text-center text-gray-700 text-lg">
          {data.description}
        </p>
        <hr />
      </>
    );
  });
}
```
### 🚀 Cambios adicionales

- Se agregaron estilos de texto para mejorar la presentación del título y la descripción.

- Se añadió un `<hr />` para separar visualmente cada tutorial.

### 📸 Vista previa esperada

- Título centrado y con formato: Hace que el título del tutorial sea visualmente destacable.
- Descripción centrada: Mejora la legibilidad de la descripción del tutorial.
- Separadores `<hr />:` Añade un margen visual que ayuda a diferenciar cada tutorial.

![issue](https://github.com/user-attachments/assets/92927d76-dc69-4aec-b2e0-f58f86af73b7)