### PR TITLE
Feat: add default value in the email_accesstoinformation field

### DIFF
--- a/src/components/Admin/Establishment/Create/EstablishmentCreateContainer.tsx
+++ b/src/components/Admin/Establishment/Create/EstablishmentCreateContainer.tsx
@@ -43,7 +43,7 @@ const EstablishmentCreateContainer = ({
         job_authority: "",
         logo: "",
         name: "",
-        email_accesstoinformation: "",
+        email_accesstoinformation: "email@example.com",
         email_committe: "",
         first_name_committe: "",
         highest_committe: "",

--- a/src/components/Admin/Establishment/Create/EstablishmentCreatePresenter.tsx
+++ b/src/components/Admin/Establishment/Create/EstablishmentCreatePresenter.tsx
@@ -317,6 +317,8 @@ const EstablishmentCreatePresenter = (props: Props) => {
                                 />
 
                             </div>
+                            {/*
+                            Campo eliminado según tarea: "En el formulario de creación de instituciones eliminar el campo 'Correo de acceso a la información'"
                             <div className="flex  flex-col m-2">
                                 <Input type={"text"}
                                     placeholder={"Correo de acceso a la información"} width="w-60"
@@ -328,7 +330,7 @@ const EstablishmentCreatePresenter = (props: Props) => {
                                     obligatorio
                                 />
                             </div>
-
+                            */}
                         </div>
                         <hr />
                         <div className="flex-col items-center justify-between  mb-52">

--- a/src/components/Admin/Establishment/Edit/EstablishmentEditContainer.tsx
+++ b/src/components/Admin/Establishment/Edit/EstablishmentEditContainer.tsx
@@ -38,7 +38,7 @@ const EstablishmentEditContainer = ({
         job_authority: "",
         logo: "",
         name: "",
-        email_accesstoinformation: "",
+        email_accesstoinformation: "email@example.com",
         email_committe: "",
         first_name_committe: "",
         highest_committe: "",

--- a/src/components/Admin/Establishment/Edit/EstablishmentEditPresenter.tsx
+++ b/src/components/Admin/Establishment/Edit/EstablishmentEditPresenter.tsx
@@ -304,6 +304,8 @@ const EstablishmentEditPresenter = (props: Props) => {
                                 />
 
                             </div>
+                            {/*
+                            Campo eliminado según tarea: "En el formulario de creación de instituciones eliminar el campo 'Correo de acceso a la información'"
                             <div className="flex  flex-col m-2">
                                 <Input type={"email"}
                                     placeholder={"Correo de acceso a la información"} width="w-60"
@@ -314,6 +316,7 @@ const EstablishmentEditPresenter = (props: Props) => {
                                     onChange={(e) => props.setData(e)}
                                 />
                             </div>
+                            */}
                         </div>
                         <hr />
                         <div className="flex-col items-center justify-between mb-52">


### PR DESCRIPTION
### Que se hizo?
Se eliminó el campo `Correo de acceso a la información` en la vista del formulario para cumplir con los requisitos de diseño. Además, se estableció un valor por defecto para este campo en el `frontend`, de modo que, al momento de crear o editar un registro, se asigne automáticamente.

### Modificaciones
`src/components/Admin/Establishment/Create`

```
const [data, setData] = useState<EstablishmentEntity>({
        abbreviation: "",
        code: "",
        email_authority: "",
        first_name_authority: "",
        highest_authority: "",
        last_name_authority: "",
        job_authority: "",
        logo: "",
        name: "",
        email_accesstoinformation: "email@example.com",
        email_committe: "",
        first_name_committe: "",
        highest_committe: "",
        job_committe: "",
        last_name_committe: "",
        identification: "",
        extra_numerals: '',
        address:""
    })
```

`src/components/Admin/Establishment/Edit`

```
const [data, setData] = useState<EstablishmentEntity>({
        abbreviation: "",
        code: "",
        email_authority: "",
        first_name_authority: "",
        highest_authority: "",
        last_name_authority: "",
        job_authority: "",
        logo: "",
        name: "",
        email_accesstoinformation: "email@example.com",
        email_committe: "",
        first_name_committe: "",
        highest_committe: "",
        job_committe: "",
        last_name_committe: "",
        identification: "",
        extra_numerals: '',
        address:""
    })
```


### Resultados
![Image](https://github.com/user-attachments/assets/edd626e8-be68-4865-85e3-95d654fd35e4)

![Image](https://github.com/user-attachments/assets/cca8b0fe-2cd4-458d-a7cf-3ac45261e960)
