### PR TITLE
Fix: cálculo correcto de días transcurridos entre fecha de solicitud

### DIFF
--- a/src/components/Transparency/Reports/AllSolicities/AllSolicitiesPresenter.tsx
+++ b/src/components/Transparency/Reports/AllSolicities/AllSolicitiesPresenter.tsx
@@ -112,9 +112,13 @@ const AllSolicitiesPresenter = (props: Props) => {
                             title: "Días transcurridos",
                             key: "date",
                             render: (solicity) => (
-                                <p>{
-                                    solicity.date ? Math.floor((new Date().getTime() - new Date(solicity.date).getTime()) / (1000 * 60 * 60 * 24)) : ""
-                                }</p>
+                                <p>
+                                    {
+                                        solicity.date && solicity.responseDate
+                                        ? Math.floor((new Date(solicity.responseDate).getTime() - new Date(solicity.date).getTime()) / (1000 * 60 * 60 * 24)) 
+                                        : ""
+                                    }
+                                </p>
                             )
                         },
 
@@ -128,7 +132,7 @@ const AllSolicitiesPresenter = (props: Props) => {
                                 const color = status?.bg || "bg-primary-500"
                                 const border = color.replace("bg", "border")
                                 return (
-                                    <p className={`text-wrap border rounded-md px-2 py-1    
+                                    <p className={`text-wrap border rounded-md px-2 py-1
                                         md:w-5/12 w-full
                                      ${border}
                                      ${color} text-white text-center


### PR DESCRIPTION
### Problema:
El cálculo de los días transcurridos usa la fecha actual como referencia (new Date().getTime()). Sin embargo, para calcular correctamente el tiempo entre la fecha de solicitud y la fecha de respuesta, debes usar ambas fechas directamente.

### Explicación:

- **Validación de fechas:** Se comprueba que existan tanto la fecha de solicitud (solicity.date) como la fecha de respuesta (solicity.responseDate) antes de realizar el cálculo.
- **Cálculo del tiempo:** Se obtiene la diferencia en milisegundos entre las dos fechas y se convierte a días (1000 * 60 * 60 * 24).