### PR TITLE
feat: agregar validación 'required' al textarea

### DIFF
--- a/src/components/Transparency/Solicity/Response/SolicityResponsePresenter.tsx
+++ b/src/components/Transparency/Solicity/Response/SolicityResponsePresenter.tsx
@@ -452,6 +452,7 @@ const SolicityResponsePresenter = (props: Props) => {
                                         props.onChangeTextResponse(e.target.value)
                                     }}
                                     ref={responseRef as React.RefObject<HTMLTextAreaElement>}
+                                    required
                                 ></Textarea>
                                 <span>
                                     {count} / 3000


### PR DESCRIPTION
Cuando se hace clic en prorroga se debe hacer el campo requerido por requerimiento.

![image](https://github.com/user-attachments/assets/359b67f8-92ae-48fc-befe-59567fce31cc)
