### PR TITLE
Feat: dividir contadores por transparencia

### DIFF
--- a/src/components/Landing/Establishment/Detail/Indicators/IndicatorsEstablishment.tsx
+++ b/src/components/Landing/Establishment/Detail/Indicators/IndicatorsEstablishment.tsx
@@ -27,7 +27,9 @@ const IndicatorsEstablishment = (props: Props) => {
         score_saip: 0,
         day_frencuency_publish:0,
         day_frencuency_response:0,
-        ta_published:0
+        ta_published:0,
+        tf_published: 0,
+        tc_published: 0
     });
     {/*const date = new Date();*/}
     {/*const monthName = date.toLocaleString('es-ES', { month: 'long' });*/}
@@ -320,18 +322,6 @@ const IndicatorsEstablishment = (props: Props) => {
                 <div className="flex flex-col items-center p-4 h-52">
                     <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-6 max-w-md w-full">
                         <h2 className="text-lg font-semibold text-gray-800 mb-4">
-                            Cantidad total de archivos de transparencia publicados en {new Date().getFullYear()}
-                        </h2>
-                        <div className="bg-blue-100 border border-blue-200 text-blue-800 rounded-lg px-4 py-2 text-center">
-                            <h4 className="text-2xl font-bold">
-                                {res.ta_published}
-                            </h4>
-                        </div>
-                    </div>
-                </div>
-                <div className="flex flex-col items-center p-4 h-52">
-                    <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-6 max-w-md w-full">
-                        <h2 className="text-lg font-semibold text-gray-800 mb-4">
                             Día del mes donde frecuentemente se publican los archivos de transparencia: 
                         </h2>
                         
@@ -343,7 +333,46 @@ const IndicatorsEstablishment = (props: Props) => {
                     </div>
                 </div>
             </div>
+            <div className="flex flex-row gap-1">
+                <div className="flex flex-col items-center p-4 h-52">
+                    <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-6 max-w-md w-full">
+                        <h2 className="text-lg font-semibold text-gray-800 mb-4">
+                            Cantidad total de archivos de transparencia activa publicados en {new Date().getFullYear()}
+                        </h2>
+                        <div className="bg-blue-100 border border-blue-200 text-blue-800 rounded-lg px-4 py-2 text-center">
+                            <h4 className="text-2xl font-bold">
+                                {res.ta_published}
+                            </h4>
+                        </div>
+                    </div>
+                </div>
 
+                <div className="flex flex-col items-center p-4 h-52">
+                    <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-6 max-w-md w-full">
+                        <h2 className="text-lg font-semibold text-gray-800 mb-4">
+                            Cantidad total de archivos de transparencia focalizada publicados en {new Date().getFullYear()}
+                        </h2>
+                        <div className="bg-blue-100 border border-blue-200 text-blue-800 rounded-lg px-4 py-2 text-center">
+                            <h4 className="text-2xl font-bold">
+                                {res.tf_published}
+                            </h4>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="flex flex-col items-center p-4 h-52">
+                    <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-6 max-w-md w-full">
+                        <h2 className="text-lg font-semibold text-gray-800 mb-4">
+                            Cantidad total de archivos de transparencia colaborativa publicados en {new Date().getFullYear()}
+                        </h2>
+                        <div className="bg-blue-100 border border-blue-200 text-blue-800 rounded-lg px-4 py-2 text-center">
+                            <h4 className="text-2xl font-bold">
+                                {res.tc_published}
+                            </h4>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </>
 
     );

--- a/src/infrastructure/Api/PublicDataApi/interface.ts
+++ b/src/infrastructure/Api/PublicDataApi/interface.ts
@@ -199,7 +199,9 @@ export interface IndicatorResponse {
     total_score: number;
     day_frencuency_publish:number,
     day_frencuency_response:number;
-    ta_published:number
+    ta_published:number;
+    tf_published: number;
+    tc_published: number;
 }
 
 


### PR DESCRIPTION
Cambios en el fron para que podamos observar la data y los contadores de archivos publicados por transparencia.

![image](https://github.com/user-attachments/assets/ef8340d5-54d7-498f-9708-3069d3bf3207)
