### PR TITLE
Feat: feat: agregar endpoint para exportar todas las solicitudes

### DIFF
--- a/src/components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentContainer.tsx
+++ b/src/components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentContainer.tsx
@@ -3,9 +3,11 @@ import { useNavigate } from "react-router-dom"
 import { useEffect, useState } from "react"
 import SolicityUseCase from "../../../../domain/useCases/SolicityUseCase/SolicityUseCase"
 import { Solicity } from "../../../../domain/entities/Solicity"
+import ReportsApi from "../../../../infrastructure/Api/Reports"
 
 interface Props {
     useCase: SolicityUseCase;
+    reportApi:ReportsApi;
 }
 
 
@@ -134,6 +136,21 @@ const SolicityListEstablishmentContainer = (props: Props) => {
             SetError(err.message)
         })
     }
+    const onExport = async () => {
+        try {
+            const response = await props.reportApi.generateReportAllSolicities(new Date().getFullYear());
+            const url = window.URL.createObjectURL(new Blob([response]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', 'TodasLasSolicitudes.xlsx'); // Nombre del archivo descargado
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        } catch (error: any) {
+            console.error("Error al descargar el reporte:", error.message);
+            alert("No se pudo descargar el reporte: " + error.message);
+        }
+    }
 
     const handleChageStatus = (e:string)=>{
         setStatus(e)
@@ -155,6 +172,7 @@ const SolicityListEstablishmentContainer = (props: Props) => {
             onChangeSort={onChangesSort}
             error={error}
             data={solicitudes}
+            onExport={onExport}
 
             onAdd={handleAdd}
             onCancelDelete={handleCancelDelete}

--- a/src/components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentPresenter.tsx
+++ b/src/components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentPresenter.tsx
@@ -38,12 +38,10 @@ interface Props {
     onChangeSort: (sort: string) => void
     columnsSort: string[]
     onChangeStatus: (value: string) => void
+    onExport: () => void
 }
 
 const SolicityListEstablishmentPresenter = (props: Props) => {
-
-    console.log("DASSSA", props.data)
-
     return (
         <>
             <h2 className='mb-4 text-balance border-b border-gray-300 pb-1 text-2xl font-bold text-primary'>
@@ -111,7 +109,12 @@ const SolicityListEstablishmentPresenter = (props: Props) => {
 
                 </div>
 
+                <div className="flex justify-end ml-28">
+                    <button className='inline-flex w-full items-center gap-2 rounded-md border border-primary px-5 py-2.5 text-center text-xs font-medium text-gray-600 transition-colors hover:bg-primary hover:text-white focus:outline-none'
 
+                        onClick={props.onExport}
+                    >Exportar</button>
+                </div>
                 <button
                     type='button'
                     onClick={props.onAdd}

--- a/src/infrastructure/Api/Reports/index.ts
+++ b/src/infrastructure/Api/Reports/index.ts
@@ -98,6 +98,25 @@ class ReportsApi {
             throw new Error(e);
         }
     }
+
+    // Nuevo método para generar el reporte de todas las solicitudes
+    async generateReportAllSolicities(year: number) {
+        try {
+            const response = await this.api.post(TRANSPARENCY_PATH + `/reports/download/reporte-todas-solicitudes`,
+                {
+                    year
+                },
+                {
+                    responseType: 'blob' // Asegúrate de manejar la respuesta como un blob para descargar el archivo
+                }
+            );
+            return response.data;
+        } catch (error: any) {
+            const e = error?.response?.data?.message || "Error al obtener el reporte";
+            throw new Error(e);
+        }
+    }
+
     
 }
 

--- a/src/interfaces/web/Transparency/Solicity/ListEstablishment/index.tsx
+++ b/src/interfaces/web/Transparency/Solicity/ListEstablishment/index.tsx
@@ -1,6 +1,7 @@
 import SolicityListEstablishmentContainer from "../../../../../components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentContainer";
 import SolicityUseCase from "../../../../../domain/useCases/SolicityUseCase/SolicityUseCase";
 import api from "../../../../../infrastructure/Api";
+import ReportsApi from "../../../../../infrastructure/Api/Reports";
 import SolicityApi from "../../../../../infrastructure/Api/Solicity/SolicityApi";
 import SolicityService from "../../../../../infrastructure/Services/SolicityService";
 
@@ -13,7 +14,7 @@ const SolicityListEstablishment = () => {
     return (
         <SolicityListEstablishmentContainer
             useCase={UseCase}
-
+            reportApi={new ReportsApi(api)}
         />
     )
 


### PR DESCRIPTION
### Features:
- Se implementó un nuevo endpoint `/reports/download/reporte-todas-solicitudes`
  que permite descargar un reporte con todas las solicitudes, 
  independientemente de su estado.
- Se ajustó el frontend para consumir este nuevo endpoint.

Esto cumple con el requerimiento de exportar todos los datos en un reporte.