### PR TITLE
FIX: Agregar ejemplo de correo en sesion

### DIFF
--- a/src/components/Admin/Establishment/InSession/EstablishmentInSessionContainer.tsx
+++ b/src/components/Admin/Establishment/InSession/EstablishmentInSessionContainer.tsx
@@ -39,7 +39,7 @@ const EstablishmentInSessionContainer = ({
         job_authority: "",
         logo: "",
         name: "",
-        email_accesstoinformation: "",
+        email_accesstoinformation: "email@example.com",
         email_committe: "",
         first_name_committe: "",
         highest_committe: "",


### PR DESCRIPTION
Agregar el ejemplo de correo en la sesion para evitar que se envie vacio, era lo que esta faltando para que funcione correctamente.