### PR TITLE
Fix: Prorroga e Insistencia en vistas

### DIFF
--- a/src/components/Transparency/Solicity/Response/SolicityResponseContainer.tsx
+++ b/src/components/Transparency/Solicity/Response/SolicityResponseContainer.tsx
@@ -79,6 +79,7 @@ const SolicityResponseContainer = (props: Props) => {
     const [isAvaliableToInsistency, setIsAvaliableToInsistency] = useState<boolean>(false)
     const [isAvaliableToResponse, setIsAvaliableToResponse] = useState<boolean>(false)
     const [isAvaliableToComment,] = useState<boolean>(false)
+    const [isAvaliableToProrroga, setIsAvaliableToProrroga] = useState<boolean>(false)
     const [textDescription, setTextDescription] = useState<string>("");
     const [files, SetFiles] = useState<{
         file: File | string | null,
@@ -568,6 +569,7 @@ const SolicityResponseContainer = (props: Props) => {
                 new_status = StatusSolicity.INSISTENCY_PERIOD.key
             } else if (solicityToResponse.status == StatusSolicity.NO_RESPONSED.key) {
                 new_status = StatusSolicity.INSISTENCY_PERIOD.key
+                setIsAvaliableToInsistency(true)
             } else if (solicityToResponse.status == StatusSolicity.INSISTENCY_RESPONSED.key) {
                 new_status = StatusSolicity.PERIOD_INFORMAL_MANAGEMENT.key
             } else if (solicityToResponse.status == StatusSolicity.INSISTENCY_NO_RESPONSED.key) {
@@ -576,6 +578,7 @@ const SolicityResponseContainer = (props: Props) => {
         } else {
             if (solicityToResponse.status == StatusSolicity.SEND.key) {
                 new_status = StatusSolicity.PRORROGA.key
+                setIsAvaliableToProrroga(true)
             }
         }
         if (new_status == '') {
@@ -590,9 +593,8 @@ const SolicityResponseContainer = (props: Props) => {
         SetSolicity(res)
         setSolicityToResponse(res)
 
-        setTextDescription(props.usecase.getDescriptionTextStatus(res, userSession.id))
-        setIsAvaliableToInsistency(true)
-
+        setTextDescription(props.usecase.getDescriptionTextStatus(res, userSession.id))      
+        
     }
 
 
@@ -613,7 +615,7 @@ const SolicityResponseContainer = (props: Props) => {
         SetSolicity(res)
         setSolicityToResponse(res)
         setIsAvaliableToInsistency(false)
-
+        setIsAvaliableToProrroga(false)
         
     }
 
@@ -684,6 +686,7 @@ const SolicityResponseContainer = (props: Props) => {
                     isLoadingSend={loading}
                     attachs={attachs}
                     isAvaliableToInsistency={isAvaliableToInsistency}
+                    isAvaliableToProrroga={isAvaliableToProrroga}
                     timeline={timeline}
                     isAvaliableToComment={isAvaliableToComment}
                     ChangeStatus={() => { changeStatus() }}

--- a/src/components/Transparency/Solicity/Response/SolicityResponsePresenter.tsx
+++ b/src/components/Transparency/Solicity/Response/SolicityResponsePresenter.tsx
@@ -80,6 +80,7 @@ interface Props {
     userSession: UserEntity;
     isAvaliableToResponse: boolean;
     isAvaliableToInsistency: boolean;
+    isAvaliableToProrroga: boolean;
     isAvaliableToComment: boolean;
     isLoadingSend: boolean
     timeline: TimeLinePresenter[];
@@ -327,8 +328,9 @@ const SolicityResponsePresenter = (props: Props) => {
                                 <span>{props.textForChangeStatus}</span>
                             </Button> </> : null
                 }
+                
                 {
-                    props.isAvaliableToInsistency ?
+                    props.isAvaliableToProrroga ?
                         <>
 
 
@@ -349,7 +351,7 @@ const SolicityResponsePresenter = (props: Props) => {
                                             "“¿Deben las entidades responder mis solicitudes?”" : ""
                                     }
                                 </Link>
-                                <div className="flex flex-col m-2 mt-16">
+                                <div className="flex flex-col m-2 mt-7">
                                     <h3 className="text-lg font-medium text-gray-800 dark:text-white">
                                         Archivo Adjunto Para Prórroga
                                     </h3>
@@ -444,6 +446,156 @@ const SolicityResponsePresenter = (props: Props) => {
                                 <Textarea
                                     placeholder={props.solicitySaved.status !== StatusSolicity.PERIOD_INFORMAL_MANAGEMENT.key ?
                                         "Escribe la explicación por la que solicitas la prórroga" :
+                                        "Escribe la explicación por la que solicitas la Gestión Oficiosa"}
+                                    name="description"
+                                    rows={5}
+                                    onChange={(e) => {
+                                        setCount(e.target.value.length)
+                                        props.onChangeTextResponse(e.target.value)
+                                    }}
+                                    ref={responseRef as React.RefObject<HTMLTextAreaElement>}
+                                    required
+                                ></Textarea>
+                                <span>
+                                    {count} / 3000
+                                </span>
+                                <Button
+                                    type="button"
+                                    color="danger"
+                                    className="text-white font-bold bg-gray-500 hover:bg-gray-700 "
+                                    onClick={props.onCancelChangeStatus}
+                                >
+                                    <IoClose size={23} className=" mr-2" />
+                                    Cancelar
+                                </Button>
+                            </div>
+
+
+                        </> : null
+                }
+                
+                {
+                    props.isAvaliableToInsistency ?
+                        <>
+
+
+                            <div>
+                                <Label
+                                    htmlFor=""
+                                    value={
+                                        props.userSession.establishment_id?
+                                        props.textForMotiveDescription:""
+                                    }
+                                    className="text-sm "
+                                />
+                                <Link
+                                    className="text-primary-600"
+                                    to="/normativa">
+                                    {
+                                        (props.userSession.id || 0) == props.solicitySaved.userCreated ?
+                                            "“¿Deben las entidades responder mis solicitudes?”" : ""
+                                    }
+                                </Link>
+                                {
+                                    /*
+                                    <div className="flex flex-col m-2 mt-16">
+                                    <h3 className="text-lg font-medium text-gray-800 dark:text-white">
+                                        Archivo Adjunto Para Prórroga
+                                    </h3>
+
+                                    <div className="flex flex-row m-2">
+                                        {
+                                            props.files.filter(x => x.file_solicity).map((file, index) => {
+                                                return (
+                                                    <div className="flex flex-col m-2 bg-slate-100 p-5 rounded-lg shadow-xl">
+                                                        <FaFile className=" text-primary-600" size={30} />
+                                                        <span className=" text-gray-500 dark:text-gray-300">
+                                                            {file.file_solicity?.name || file.file_solicity?.description}
+                                                        </span>
+                                                        <span className=" text-gray-500 text-sm dark:text-gray-300">
+                                                            { }
+                                                        </span>
+                                                        <span className="mt-5 text-gray-500 text-sm dark:text-gray-300">
+                                                            <FaTrash className=" text-red-600" size={15} onClick={() => props.onRemoveFileFromSolicity(index, "file")} />
+                                                        </span>
+                                                    </div>
+                                                )
+
+                                            })
+                                        }
+                                    </div>
+                                </div>
+                                <h4>
+                                    Si desea adjuntar archivo como parte del motivo de prórroga, seleccione a continuación
+                                </h4>
+                                <Tabs aria-label="Datos" className="bg-white dark:bg-gray-800"
+                                    theme={themeTabs}
+                                    style="underline"
+
+                                >
+
+                                    <Tabs.Item title="Subir Archivo">
+                                        <div className="flex-col m-2">
+
+                                            {
+                                                props.files.map((file, index) => {
+                                                    if (file.type === "file") {
+                                                        return (
+                                                            <div className="flex flex-row  m-2">
+                                                                <FileUploadForm
+
+                                                                    onSave={(
+                                                                        file, name, description
+                                                                    ) => { props.onSaveFile(file, name, description, index) }}
+                                                                    isSaved={file.file_solicity !== null}
+                                                                    loading={file.loading}
+                                                                    percent={file.percent}
+                                                                    key={index}
+                                                                    onCancel={() => props.onRemoveFileFromSolicity(index, "file")}
+                                                                />
+
+                                                            </div>
+                                                        )
+                                                    }
+                                                })
+                                            }
+
+
+                                            <div className="flex items-center justify-center mt-4 gap-x-3 w-full">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => props.onAddDataSet("file")}
+                                                    className='flex items-center gap-2 rounded-md border 
+                                                border-primary px-2 py-1 font-medium text-primary hover:bg-primary hover:text-white'>
+                                                    <svg
+                                                        xmlns='http://www.w3.org/2000/svg'
+                                                        height='24px'
+                                                        viewBox='0 -960 960 960'
+                                                        width='24px'
+                                                        fill='currentColor'
+                                                    ><path
+                                                        d='M440-280h80v-160h160v-80H520v-160h-80v160H280v80h160v160Zm40 200q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'
+                                                    ></path>
+                                                    </svg>
+                                                    <span>Agregar adjunto</span>
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                    </Tabs.Item>
+                                    
+                                </Tabs>
+                                <label></label>
+                                <label></label>
+                                <label className="m-6">Motivo de prórroga</label>
+                                <label></label>
+                                <label></label>
+                                */
+                                }
+                                
+                                <Textarea
+                                    placeholder={props.solicitySaved.status !== StatusSolicity.PERIOD_INFORMAL_MANAGEMENT.key ?
+                                        "Escribe la explicación por la que solicitas la insistencia" :
                                         "Escribe la explicación por la que solicitas la Gestión Oficiosa"}
                                     name="description"
                                     rows={5}

--- a/src/domain/entities/Solicity.ts
+++ b/src/domain/entities/Solicity.ts
@@ -150,7 +150,7 @@ export class Solicity extends BaseEntity {
             //    undefined               // Fecha opcional
             //));
             list.push(new TimeLinePresenter(c.user, c.created_at, c.motive, c.files, [],
-                "COMMENT", "Motivo de Prórroga", 'Motivo de Prórroga'))
+                "COMMENT", "Motivo de Insistencia", 'Motivo de Prórroga'))
         })
 
 


### PR DESCRIPTION
Agregar la vista correcta en la solicitud, ejm:
- En la vista del ciudadano no debe aparecer la prórroga, pero si la insistencia.
- En la vista del supervisor o cualquiera que visualice la solicitud que no sea ciudadano, cuando active la prórroga debe visualizar solo contenido de la prórroga y no de la insistencia.

Usuario Supervisor *(Prorroga)*

![image](https://github.com/user-attachments/assets/54408969-30e6-4652-ba78-d694970fc694)

Usuario Ciudadano *(Insistencia)*

![image](https://github.com/user-attachments/assets/fb8cc0d7-0cc1-4149-becf-7aabf7b212ab)
