### PR TITLE
FIX: Reducir fuente, relleno y ajustar columna

### DIFF
--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -60,11 +60,11 @@ export class Transform {
             autoTable(doc, {
                 head: [headers],
                 body: data,
-                startY: doc.previousAutoTable?.finalY || 0 + 10,
+                startY: doc.previousAutoTable?.finalY ? doc.previousAutoTable.finalY + 10 : 20,
                 margin: { horizontal: 10 },
                 styles: {
-                    fontSize: 8,
-                    cellPadding: 1,
+                    fontSize: 7, // Reducir fuente
+                    cellPadding: 0.7, // Reducir relleno
                     overflow: "linebreak",
                     halign: "center",
                     valign: "middle"
@@ -77,10 +77,10 @@ export class Transform {
                 columnStyles: Array(headers.length)
                     .fill(0)
                     .reduce((acc, _, index) => {
-                        acc[index] = { columnWidth: "auto" };
+                        acc[index] = { columnWidth: "wrap" }; // Ajustar columnas
                         return acc;
                     }, {})
-            });
+            });            
 
             // Guardar el PDF
             doc.save(`${name}.pdf`);


### PR DESCRIPTION
## Para todos los archivos que no se pueden descargar desde `Publicaciones T. Activa`:
## Problema:
No se descargan en ciertos archivos como en el reportado para el `Numeral 5.22` y otros.

## Solución:
Se ha identificado el problema en la librería `jspdf` al momento de convertir los archivos desde `csv` a `pdfLandScape`, por lo que se redujo la fuente, el relleno y ajustamos la columna. Es probable que para varios archivos no se pueda controlar y se vea mal por lo que se espera una mejora visual.