### PR TITLE
FIX: detener reloj en insistencia respondida

### DIFF
--- a/src/components/Transparency/Reports/AllSolicities/AllSolicitiesPresenter.tsx
+++ b/src/components/Transparency/Reports/AllSolicities/AllSolicitiesPresenter.tsx
@@ -136,6 +136,9 @@ const AllSolicitiesPresenter = (props: Props) => {
                                         // Usar `updated_at` como fecha de fin en solicitudes respondidas
                                         endDate = solicity.updated_at;
                                         break;
+                                    case "INSISTENCY_RESPONSED":
+                                        endDate = solicity.updated_at
+                                        break;
                             
                                     case "PRORROGA":
                                     case "NO_RESPONSED":

--- a/src/components/Transparency/Reports/SolicitiesNoResponses/SolicitiesNoResponsePresenter.tsx
+++ b/src/components/Transparency/Reports/SolicitiesNoResponses/SolicitiesNoResponsePresenter.tsx
@@ -135,6 +135,9 @@ const SolicitiesNoResponsePresenter = (props: Props) => {
                                         // Usar `updated_at` como fecha de fin en solicitudes respondidas
                                         endDate = solicity.updated_at;
                                         break;
+                                    case "INSISTENCY_RESPONSED":
+                                        endDate = solicity.updated_at
+                                        break;
                             
                                     case "PRORROGA":
                                     case "NO_RESPONSED":

--- a/src/components/Transparency/Solicity/All/AllSolicitiesPresenter.tsx
+++ b/src/components/Transparency/Solicity/All/AllSolicitiesPresenter.tsx
@@ -195,7 +195,10 @@ const AllSolicitiesPresenter = (props: Props) => {
                                         // Usar `updated_at` como fecha de fin en solicitudes respondidas
                                         endDate = solicity.updated_at;
                                         break;
-                            
+                                    case "INSISTENCY_RESPONSED":
+                                        endDate = solicity.updated_at
+                                        break;
+
                                     case "PRORROGA":
                                     case "NO_RESPONSED":
                                     case "INSISTENCY_NO_RESPONSED":

--- a/src/components/Transparency/Solicity/List/SoicityListPresenter.tsx
+++ b/src/components/Transparency/Solicity/List/SoicityListPresenter.tsx
@@ -259,6 +259,9 @@ const SolicityListPresenter = (props: Props) => {
                                         // Usar `updated_at` como fecha de fin en solicitudes respondidas
                                         endDate = solicity.updated_at;
                                         break;
+                                    case "INSISTENCY_RESPONSED":
+                                        endDate = solicity.updated_at
+                                        break;
                             
                                     case "PRORROGA":
                                     case "NO_RESPONSED":

--- a/src/components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentPresenter.tsx
+++ b/src/components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentPresenter.tsx
@@ -215,6 +215,9 @@ const SolicityListEstablishmentPresenter = (props: Props) => {
                                         // Usar `updated_at` como fecha de fin en solicitudes respondidas
                                         endDate = solicity.updated_at;
                                         break;
+                                    case "INSISTENCY_RESPONSED":
+                                        endDate = solicity.updated_at
+                                        break;
                             
                                     case "PRORROGA":
                                     case "NO_RESPONSED":


### PR DESCRIPTION
## Caso Detectado #39 :
Cuando se contabiliza el reloj de las saip desde que el ciudadano envía hasta cuando responde hay un tiempo que debe calcularse, si ya responde debe parar el contador. Sin embargo, encontré este caso `SAIP-2024-0000001108` que el contador no se detiene y no se va a detener porque no se contempla ese caso.
*(Observar 'dias transcurridos' en la imagen)*

![antes_de_corregir](https://github.com/user-attachments/assets/748e257a-7e79-4850-a4f4-e62b530f653d)

## Resolución:
Se ha hecho la debida modificación esto es tomar en cuenta el caso `INSISTENCY_RESPONSE` para detener el contador. Con esto se evita que suceda mas casos como el `SAIP-2024-0000001108` que el contador sea infinito si ya se respondió. 
*(Observar 'dias transcurridos' en la imagen)*

![despues_de_corregir](https://github.com/user-attachments/assets/5c471545-c86b-4020-9df7-d45107074471)

## Archivos modificados
src/components/Transparency/Reports/AllSolicities/AllSolicitiesPresenter.tsx
src/components/Transparency/Reports/SolicitiesNoResponses/SolicitiesNoResponsePresenter.tsx
src/components/Transparency/Solicity/All/AllSolicitiesPresenter.tsx
src/components/Transparency/Solicity/List/SoicityListPresenter.tsx
src/components/Transparency/Solicity/ListEstablishment/SolicityEstablishmentPresenter.tsx